### PR TITLE
Add options to include OData query parameters

### DIFF
--- a/Calendar_test.go
+++ b/Calendar_test.go
@@ -7,6 +7,9 @@ import (
 
 func TestCalendar_String(t *testing.T) {
 	testCalendars := GetTestListCalendars(t)
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 
 	for _, testCalendar := range testCalendars {
 		tt := struct {

--- a/Calendars_test.go
+++ b/Calendars_test.go
@@ -8,7 +8,11 @@ import (
 // GetTestListCalendars tries to get a valid User from the User-test cases
 // and then uses ListCalendars() for this instance.
 func GetTestListCalendars(t *testing.T) Calendars {
+	t.Helper()
 	testUser := GetTestUser(t)
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 	testCalendars, err := testUser.ListCalendars()
 	if err != nil {
 		t.Fatalf("Cannot User.ListCalendars() for user %v: %v", testUser, err)
@@ -21,7 +25,9 @@ func GetTestListCalendars(t *testing.T) Calendars {
 
 func TestCalendars_GetByName(t *testing.T) {
 	testCalendars := GetTestListCalendars(t)
-
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 	type args struct {
 		name string
 	}
@@ -55,6 +61,9 @@ func TestCalendars_GetByName(t *testing.T) {
 }
 
 func TestCalendars_String(t *testing.T) {
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 	testCalendars := GetTestListCalendars(t)
 
 	// write custom string func

--- a/Group.go
+++ b/Group.go
@@ -41,9 +41,10 @@ func (g *Group) setGraphClient(gC *GraphClient) {
 // ListMembers - Get a list of the group's direct members. A group can have users,
 // contacts, and other groups as members. This operation is not transitive. This
 // method will currently ONLY return User-instances of members
+// Supports optional OData query parameters https://docs.microsoft.com/en-us/graph/query-parameters
 //
 // See https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/group_list_members
-func (g Group) ListMembers() (Users, error) {
+func (g Group) ListMembers(opts ...ListQueryOption) (Users, error) {
 	if g.graphClient == nil {
 		return nil, ErrNotGraphClientSourced
 	}
@@ -53,7 +54,7 @@ func (g Group) ListMembers() (Users, error) {
 		Users Users `json:"value"`
 	}
 	marsh.Users.setGraphClient(g.graphClient)
-	return marsh.Users, g.graphClient.makeGETAPICall(resource, nil, &marsh)
+	return marsh.Users, g.graphClient.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 }
 
 // UnmarshalJSON implements the json unmarshal to be used by the json-library

--- a/Group_test.go
+++ b/Group_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 func GetTestGroup(t *testing.T) Group {
-	TestEnvironmentVariablesPresent(t) // checks the env-variables and failsNow if any is missing
 	groups, err := graphClient.ListGroups()
 	if err != nil {
 		t.Fatalf("Cannot GraphClient.ListGroups(): %v", err)

--- a/Security.go
+++ b/Security.go
@@ -187,12 +187,13 @@ type VulnerabilityState struct {
 }
 
 // ListAlerts returns a slice of Alert objects from MS Graph's security API. Each Alert represents a security event reported by some component.
-func (g *GraphClient) ListAlerts() ([]Alert, error) {
+// Supports optional OData query parameters https://docs.microsoft.com/en-us/graph/query-parameters
+func (g *GraphClient) ListAlerts(opts ...ListQueryOption) ([]Alert, error) {
 	resource := "/security/alerts"
 	var marsh struct {
 		Alerts []Alert `json:"value"`
 	}
-	err := g.makeGETAPICall(resource, nil, &marsh)
+	err := g.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 	return marsh.Alerts, err
 }
 
@@ -227,13 +228,14 @@ type ControlScore struct {
 }
 
 // ListSecureScores returns a slice of SecureScore objects. Each SecureScore represents
+// Supports optional OData query parameters https://docs.microsoft.com/en-us/graph/query-parameters
 // a tenant's security score for a particular day.
-func (g *GraphClient) ListSecureScores() ([]SecureScore, error) {
+func (g *GraphClient) ListSecureScores(opts ...ListQueryOption) ([]SecureScore, error) {
 	resource := "/security/secureScores"
 	var marsh struct {
 		Scores []SecureScore `json:"value"`
 	}
-	err := g.makeGETAPICall(resource, nil, &marsh)
+	err := g.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 	return marsh.Scores, err
 }
 
@@ -287,11 +289,12 @@ type SecureScoreControlStateUpdate struct {
 // ListSecureScoreControlProfiles returns a slice of SecureScoreControlProfile objects.
 // Each object represents a secure score control profile, which is used when calculating
 // a tenant's secure score.
-func (g *GraphClient) ListSecureScoreControlProfiles() ([]SecureScoreControlProfile, error) {
+// Supports optional OData query parameters https://docs.microsoft.com/en-us/graph/query-parameters
+func (g *GraphClient) ListSecureScoreControlProfiles(opts ...ListQueryOption) ([]SecureScoreControlProfile, error) {
 	resource := "/security/secureScoreControlProfiles"
 	var marsh struct {
 		Profiles []SecureScoreControlProfile `json:"value"`
 	}
-	err := g.makeGETAPICall(resource, nil, &marsh)
+	err := g.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 	return marsh.Profiles, err
 }

--- a/User_test.go
+++ b/User_test.go
@@ -8,7 +8,6 @@ import (
 // GetTestUser returns a valid User instance for testing. Will issue a t.Fatalf if the
 // user cannot be loaded
 func GetTestUser(t *testing.T) User {
-	TestEnvironmentVariablesPresent(t)
 	userToTest, errUserToTest := graphClient.GetUser(msGraphExistingUserPrincipalInGroup)
 	if errUserToTest != nil {
 		t.Fatalf("Cannot find user %v for Testing", msGraphExistingUserPrincipalInGroup)
@@ -18,6 +17,9 @@ func GetTestUser(t *testing.T) User {
 
 func TestUser_getTimeZoneChoices(t *testing.T) {
 	userToTest := GetTestUser(t)
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 
 	tests := []struct {
 		name    string
@@ -34,7 +36,7 @@ func TestUser_getTimeZoneChoices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := tt.u.getTimeZoneChoices()
+			_, err := tt.u.getTimeZoneChoices(compileGetQueryOptions([]GetQueryOption{}))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("User.getTimeZoneChoices() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -46,6 +48,9 @@ func TestUser_getTimeZoneChoices(t *testing.T) {
 }
 
 func TestUser_ListCalendars(t *testing.T) {
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 	userToTest := GetTestUser(t)
 
 	var wantedCalendars []Calendar
@@ -87,6 +92,9 @@ func TestUser_ListCalendars(t *testing.T) {
 }
 
 func TestUser_ListCalendarView(t *testing.T) {
+	if skipCalendarTests {
+		t.Skip("Skipping due to missing 'MSGraphExistingCalendarsOfUser' value")
+	}
 	userToTest := GetTestUser(t)
 
 	type args struct {


### PR DESCRIPTION
- add optional context to GET requests to allow cancellation
- support $select, $search and $filter where applicable
- make calendar tests optional in case someone has no Office365 and is not able to provide corresponding values

Co-authored-by: Mattes83

Closes #7 