### PR TITLE
add functions GraphClient.GetToken, (User/Group).GetMemberGroupsAsStrings and Group.ListTransitiveMembers

### DIFF
--- a/GraphClient.go
+++ b/GraphClient.go
@@ -365,7 +365,7 @@ func (g *GraphClient) ListGroups(opts ...ListQueryOption) (Groups, error) {
 // You can specify the securityGroupsEnabled parameter to only return security group IDs.
 //
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
-func (g *GraphClient) getMemberGroups(identifier string, securityGroupsEnabeled bool, opts *getQueryOptions) ([]string, error) {
+func (g *GraphClient) getMemberGroups(identifier string, securityGroupsEnabeled bool, opts ...GetQueryOption) ([]string, error) {
 	resource := fmt.Sprintf("/users/%v/getMemberGroups", identifier)
 	var post struct {
 		SecurityEnabledOnly bool `json:"securityEnabledOnly"`
@@ -380,7 +380,7 @@ func (g *GraphClient) getMemberGroups(identifier string, securityGroupsEnabeled 
 	}
 	body := bytes.NewReader(bodyBytes)
 
-	err = g.makePOSTAPICall(resource, opts, body, &marsh)
+	err = g.makePOSTAPICall(resource, compileGetQueryOptions(opts), body, &marsh)
 	return marsh.Groups, err
 }
 

--- a/GraphClient.go
+++ b/GraphClient.go
@@ -365,15 +365,15 @@ func (g *GraphClient) ListGroups(opts ...ListQueryOption) (Groups, error) {
 // You can specify the securityGroupsEnabled parameter to only return security group IDs.
 //
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
-func (g *GraphClient) getMemberGroups(identifier string, securityGroupsEnabeled bool, opts ...GetQueryOption) ([]string, error) {
-	resource := fmt.Sprintf("/users/%v/getMemberGroups", identifier)
+func (g *GraphClient) getMemberGroups(identifier string, securityEnabledOnly bool, opts ...GetQueryOption) ([]string, error) {
+	resource := fmt.Sprintf("/directoryObjects/%v/getMemberGroups", identifier)
 	var post struct {
 		SecurityEnabledOnly bool `json:"securityEnabledOnly"`
 	}
 	var marsh struct {
 		Groups []string `json:"value"`
 	}
-	post.SecurityEnabledOnly = securityGroupsEnabeled
+	post.SecurityEnabledOnly = securityEnabledOnly
 	bodyBytes, err := json.Marshal(post)
 	if err != nil {
 		return marsh.Groups, err

--- a/GraphClient.go
+++ b/GraphClient.go
@@ -5,7 +5,6 @@ package msgraph
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -366,7 +365,7 @@ func (g *GraphClient) ListGroups(opts ...ListQueryOption) (Groups, error) {
 // You can specify the securityGroupsEnabled parameter to only return security group IDs.
 //
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
-func (g *GraphClient) getMemberGroups(identifier string, ctx context.Context, securityGroupsEnabeled bool) ([]string, error) {
+func (g *GraphClient) getMemberGroups(identifier string, securityGroupsEnabeled bool, opts *getQueryOptions) ([]string, error) {
 	resource := fmt.Sprintf("/users/%v/getMemberGroups", identifier)
 	var post struct {
 		SecurityEnabledOnly bool `json:"securityEnabledOnly"`
@@ -380,11 +379,8 @@ func (g *GraphClient) getMemberGroups(identifier string, ctx context.Context, se
 		return marsh.Groups, err
 	}
 	body := bytes.NewReader(bodyBytes)
-	//Query Options not supported
-	reqParams := compileListQueryOptions(nil)
-	reqParams.ctx = ctx
 
-	err = g.makePOSTAPICall(resource, reqParams, body, &marsh)
+	err = g.makePOSTAPICall(resource, opts, body, &marsh)
 	return marsh.Groups, err
 }
 

--- a/GraphClient.go
+++ b/GraphClient.go
@@ -5,6 +5,7 @@ package msgraph
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -271,10 +272,11 @@ func (g *GraphClient) ListGroups(opts ...ListQueryOption) (Groups, error) {
 	return marsh.Groups, err
 }
 
-// ListUserGroups returns a list of all group ids the user is a member of
+// getMemberGroups returns a list of all group ids the user is a member of
 // You can specify the securityGroupsEnabeled parameter to only return security group ids
+//
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
-func (g *GraphClient) ListUserGroups(identifier string, securityGroupsEnabeled bool) ([]string, error) {
+func (g *GraphClient) getMemberGroups(identifier string, ctx context.Context, securityGroupsEnabeled bool) ([]string, error) {
 	resource := fmt.Sprintf("/users/%v/getMemberGroups", identifier)
 	var post struct {
 		SecurityEnabledOnly bool `json:"securityEnabledOnly"`
@@ -290,7 +292,8 @@ func (g *GraphClient) ListUserGroups(identifier string, securityGroupsEnabeled b
 	body := bytes.NewReader(bodyBytes)
 	//Query Options not supported
 	reqParams := compileListQueryOptions(nil)
-	
+	reqParams.ctx = ctx
+
 	err = g.makePOSTAPICall(resource, reqParams, body, &marsh)
 	return marsh.Groups, err
 }

--- a/GraphClient.go
+++ b/GraphClient.go
@@ -133,7 +133,7 @@ func (g *GraphClient) refreshToken() error {
 	return err
 }
 
-// returns client Token
+// GetToken returns a copy the currently token used by this GraphClient instance.
 func (g *GraphClient) GetToken() Token {
 	return g.token
 }
@@ -362,8 +362,8 @@ func (g *GraphClient) ListGroups(opts ...ListQueryOption) (Groups, error) {
 	return marsh.Groups, err
 }
 
-// getMemberGroups returns a list of all group ids the user is a member of
-// You can specify the securityGroupsEnabeled parameter to only return security group ids
+// getMemberGroups returns a list of all group IDs the user is a member of.
+// You can specify the securityGroupsEnabled parameter to only return security group IDs.
 //
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
 func (g *GraphClient) getMemberGroups(identifier string, ctx context.Context, securityGroupsEnabeled bool) ([]string, error) {

--- a/Group.go
+++ b/Group.go
@@ -59,6 +59,7 @@ func (g Group) ListMembers(opts ...ListQueryOption) (Users, error) {
 
 // Get a list of the group's members. A group can have users, devices, organizational contacts, and other groups as members.
 // This operation is transitive and returns a flat list of all nested members.
+// This method will currently ONLY return User-instances of members
 // Supports optional OData query parameters https://docs.microsoft.com/en-us/graph/query-parameters
 //
 // See https://docs.microsoft.com/en-us/graph/api/group-list-transitivemembers?view=graph-rest-1.0&tabs=http
@@ -74,7 +75,6 @@ func (g Group) ListTransitiveMembers(opts ...ListQueryOption) (Users, error) {
 	marsh.Users.setGraphClient(g.graphClient)
 	return marsh.Users, g.graphClient.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 }
-
 
 // UnmarshalJSON implements the json unmarshal to be used by the json-library
 func (g *Group) UnmarshalJSON(data []byte) error {

--- a/Group.go
+++ b/Group.go
@@ -57,6 +57,25 @@ func (g Group) ListMembers(opts ...ListQueryOption) (Users, error) {
 	return marsh.Users, g.graphClient.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 }
 
+// Get a list of the group's members. A group can have users, devices, organizational contacts, and other groups as members.
+// This operation is transitive and returns a flat list of all nested members.
+// Supports optional OData query parameters https://docs.microsoft.com/en-us/graph/query-parameters
+//
+// See https://docs.microsoft.com/en-us/graph/api/group-list-transitivemembers?view=graph-rest-1.0&tabs=http
+func (g Group) ListTransitiveMembers(opts ...ListQueryOption) (Users, error) {
+	if g.graphClient == nil {
+		return nil, ErrNotGraphClientSourced
+	}
+	resource := fmt.Sprintf("/groups/%v/transitiveMembers", g.ID)
+
+	var marsh struct {
+		Users Users `json:"value"`
+	}
+	marsh.Users.setGraphClient(g.graphClient)
+	return marsh.Users, g.graphClient.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
+}
+
+
 // UnmarshalJSON implements the json unmarshal to be used by the json-library
 func (g *Group) UnmarshalJSON(data []byte) error {
 	tmp := struct {

--- a/Group.go
+++ b/Group.go
@@ -76,6 +76,18 @@ func (g Group) ListTransitiveMembers(opts ...ListQueryOption) (Users, error) {
 	return marsh.Users, g.graphClient.makeGETAPICall(resource, compileListQueryOptions(opts), &marsh)
 }
 
+// GetMemberGroupsAsStrings returns a list of all group IDs the user is a member of.
+//
+// opts ...GetQueryOption - only msgraph.GetWithContext is supported.
+//
+// Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
+func (g Group) GetMemberGroupsAsStrings(opts ...GetQueryOption) ([]string, error) {
+	if g.graphClient == nil {
+		return nil, ErrNotGraphClientSourced
+	}
+	return g.graphClient.getMemberGroups(g.ID, false, opts...) // securityEnabledOnly is not supported for Groups, see documentation / API-reference
+}
+
 // UnmarshalJSON implements the json unmarshal to be used by the json-library
 func (g *Group) UnmarshalJSON(data []byte) error {
 	tmp := struct {

--- a/Group_test.go
+++ b/Group_test.go
@@ -82,3 +82,35 @@ func TestGroup_String(t *testing.T) {
 		})
 	}
 }
+
+func TestGroup_ListTransitiveMembers(t *testing.T) {
+	testGroup := GetTestGroup(t)
+
+	tests := []struct {
+		name    string
+		g       Group
+		wantErr bool
+	}{
+		{
+			name:    "GraphClient created Group",
+			g:       testGroup,
+			wantErr: false,
+		}, {
+			name:    "Not GraphClient created Group",
+			g:       Group{DisplayName: "Test not GraphClient sourced"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.g.ListTransitiveMembers()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Group.ListTransitiveMembers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(got) == 0 {
+				t.Errorf("Group.ListTransitiveMembers() = %v, want at least one member of that group", got)
+			}
+		})
+	}
+}

--- a/Group_test.go
+++ b/Group_test.go
@@ -114,3 +114,40 @@ func TestGroup_ListTransitiveMembers(t *testing.T) {
 		})
 	}
 }
+
+func TestGroup_GetMemberGroupsAsStrings(t *testing.T) {
+	testGroup := GetTestGroup(t)
+
+	tests := []struct {
+		name    string
+		g       Group
+		opts    []GetQueryOption
+		wantErr bool
+	}{
+		{
+			name:    "Test group func GetMembershipGroupsAsStrings",
+			g:       testGroup,
+			wantErr: false,
+		}, {
+			name:    "Test group func GetMembershipGroupsAsStrings - no securityGroupsEnabeledF",
+			g:       testGroup,
+			wantErr: false,
+		},
+		{
+			name:    "Group not initialized by GraphClient",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.g.GetMemberGroupsAsStrings(tt.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Group.GetMemberGroupsAsStrings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && len(got) == 0 {
+				t.Errorf("Group.GetMemberGroupsAsStrings() = %v, len(%d), want at least one value", got, len(got))
+			}
+		})
+	}
+}

--- a/Group_test.go
+++ b/Group_test.go
@@ -109,7 +109,7 @@ func TestGroup_ListTransitiveMembers(t *testing.T) {
 				return
 			}
 			if !tt.wantErr && len(got) == 0 {
-				t.Errorf("Group.ListTransitiveMembers() = %v, want at least one member of that group", got)
+				t.Errorf("Group.ListTransitiveMembers() = %v, len(%d), want at least one member of that group", got, len(got))
 			}
 		})
 	}

--- a/User.go
+++ b/User.go
@@ -155,7 +155,7 @@ func (u User) GetMemberGroupsAsStrings(securityGroupsEnabeled bool, opts ...GetQ
 	if u.graphClient == nil {
 		return nil, ErrNotGraphClientSourced
 	}
-	return u.graphClient.getMemberGroups(u.ID, securityGroupsEnabeled, compileGetQueryOptions(opts))
+	return u.graphClient.getMemberGroups(u.ID, securityGroupsEnabeled, opts...)
 }
 
 // PrettySimpleString returns the User-instance simply formatted for logging purposes: {FullName (email) (activePhone)}

--- a/User.go
+++ b/User.go
@@ -2,6 +2,7 @@ package msgraph
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -143,6 +144,14 @@ func (u User) GetShortName() string {
 // GetFullName returns the full name in that format: <firstname> <lastname>
 func (u User) GetFullName() string {
 	return fmt.Sprintf("%v %v", u.GivenName, u.Surname)
+}
+
+// GetMemberGroupsAsStrings returns a list of all group ids the user is a member of
+// You can specify the securityGroupsEnabeled parameter to only return security group ids
+//
+// Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
+func (u User) GetMemberGroupsAsStrings(ctx context.Context, securityGroupsEnabeled bool) ([]string, error) {
+	return u.graphClient.getMemberGroups(u.ID, ctx, securityGroupsEnabeled)
 }
 
 // UpdateUser patches this user object. Note, only set the fields that should be changed.

--- a/User.go
+++ b/User.go
@@ -2,7 +2,6 @@ package msgraph
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -146,15 +145,17 @@ func (u User) GetFullName() string {
 	return fmt.Sprintf("%v %v", u.GivenName, u.Surname)
 }
 
-// GetMemberGroupsAsStrings returns a list of all group ids the user is a member of
-// You can specify the securityGroupsEnabeled parameter to only return security group ids
+// GetMemberGroupsAsStrings returns a list of all group IDs the user is a member of.
+// You can specify the securityGroupsEnabeled parameter to only return security group IDs.
+//
+// opts ...GetQueryOption - only msgraph.GetWithContext is supported.
 //
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
-func (u User) GetMemberGroupsAsStrings(ctx context.Context, securityGroupsEnabeled bool) ([]string, error) {
+func (u User) GetMemberGroupsAsStrings(securityGroupsEnabeled bool, opts ...GetQueryOption) ([]string, error) {
 	if u.graphClient == nil {
 		return nil, ErrNotGraphClientSourced
 	}
-	return u.graphClient.getMemberGroups(u.ID, ctx, securityGroupsEnabeled)
+	return u.graphClient.getMemberGroups(u.ID, securityGroupsEnabeled, compileGetQueryOptions(opts))
 }
 
 // PrettySimpleString returns the User-instance simply formatted for logging purposes: {FullName (email) (activePhone)}

--- a/User.go
+++ b/User.go
@@ -151,6 +151,9 @@ func (u User) GetFullName() string {
 //
 // Reference: https://docs.microsoft.com/en-us/graph/api/directoryobject-getmembergroups?view=graph-rest-1.0&tabs=http
 func (u User) GetMemberGroupsAsStrings(ctx context.Context, securityGroupsEnabeled bool) ([]string, error) {
+	if u.graphClient == nil {
+		return nil, ErrNotGraphClientSourced
+	}
 	return u.graphClient.getMemberGroups(u.ID, ctx, securityGroupsEnabeled)
 }
 

--- a/User_test.go
+++ b/User_test.go
@@ -3,7 +3,6 @@ package msgraph
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -178,7 +177,6 @@ func TestUser_GetMemberGroupsAsStrings(t *testing.T) {
 		name    string
 		u       User
 		args    args
-		want    []string
 		wantErr bool
 	}{
 		{
@@ -195,17 +193,16 @@ func TestUser_GetMemberGroupsAsStrings(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			got, err := u.GetMemberGroupsAsStrings(tt.args.ctx, tt.args.securityGroupsEnabeled)
+			got, err := tt.u.GetMemberGroupsAsStrings(tt.args.ctx, tt.args.securityGroupsEnabeled)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("User.GetMemberGroupsAsStrings() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("User.GetMemberGroupsAsStrings() = %v, want %v", got, tt.want)
+			if !tt.wantErr && len(got) == 0 {
+				t.Errorf("User.GetMemberGroupsAsStrings() = %v, want at least one value", got)
 			}
 		})
-  }
+	}
 }
 
 func TestUser_UpdateUser(t *testing.T) {

--- a/User_test.go
+++ b/User_test.go
@@ -1,7 +1,6 @@
 package msgraph
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -169,37 +168,42 @@ func TestUser_String(t *testing.T) {
 
 func TestUser_GetMemberGroupsAsStrings(t *testing.T) {
 	u := GetTestUser(t)
-	type args struct {
-		ctx                    context.Context
-		securityGroupsEnabeled bool
-	}
 	tests := []struct {
-		name    string
-		u       User
-		args    args
-		wantErr bool
+		name                   string
+		u                      User
+		securityGroupsEnabeled bool
+		opt                    GetQueryOption
+		wantErr                bool
 	}{
 		{
-			name:    "Test user func GetMembershipGroupsAsStrings",
-			u:       u,
-			args:    args{ctx: context.Background(), securityGroupsEnabeled: true},
-			wantErr: false,
+			name:                   "Test user func GetMembershipGroupsAsStrings",
+			u:                      u,
+			securityGroupsEnabeled: true,
+			opt:                    GetWithContext(nil),
+			wantErr:                false,
+		}, {
+			name:                   "Test user func GetMembershipGroupsAsStrings - no securityGroupsEnabeledF",
+			u:                      u,
+			securityGroupsEnabeled: false,
+			opt:                    GetWithContext(nil),
+			wantErr:                false,
 		},
 		{
-			name:    "User not initialized by GraphClient",
-			args:    args{ctx: context.Background(), securityGroupsEnabeled: true},
-			wantErr: true,
+			name:                   "User not initialized by GraphClient",
+			securityGroupsEnabeled: true,
+			opt:                    GetWithContext(nil),
+			wantErr:                true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.u.GetMemberGroupsAsStrings(tt.args.ctx, tt.args.securityGroupsEnabeled)
+			got, err := tt.u.GetMemberGroupsAsStrings(tt.securityGroupsEnabeled, tt.opt)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("User.GetMemberGroupsAsStrings() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !tt.wantErr && len(got) == 0 {
-				t.Errorf("User.GetMemberGroupsAsStrings() = %v, want at least one value", got)
+				t.Errorf("User.GetMemberGroupsAsStrings() = %v, len(%d), want at least one value", got, len(got))
 			}
 		})
 	}

--- a/User_test.go
+++ b/User_test.go
@@ -1,7 +1,9 @@
 package msgraph
 
 import (
+	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -157,4 +159,44 @@ func TestUser_String(t *testing.T) {
 			t.Errorf("User.String() = %v, want %v", got, tt.want)
 		}
 	})
+}
+
+func TestUser_GetMemberGroupsAsStrings(t *testing.T) {
+	u := GetTestUser(t)
+	type args struct {
+		ctx                    context.Context
+		securityGroupsEnabeled bool
+	}
+	tests := []struct {
+		name    string
+		u       User
+		args    args
+		want    []string
+		wantErr bool
+	}{
+		{
+			name:    "Test user func GetMembershipGroupsAsStrings",
+			u:       u,
+			args:    args{ctx: context.Background(), securityGroupsEnabeled: true},
+			wantErr: false,
+		},
+		{
+			name:    "User not initialized by GraphClient",
+			args:    args{ctx: context.Background(), securityGroupsEnabeled: true},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got, err := u.GetMemberGroupsAsStrings(tt.args.ctx, tt.args.securityGroupsEnabeled)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("User.GetMemberGroupsAsStrings() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("User.GetMemberGroupsAsStrings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Added:

- GetToken() - returns ms Graph Client token 
- ListUserGroups() - returns an array of the group IDs the user is a member of. You can specify the securityGroupsEnabeled parameter to only return security group IDs
- ListTransitiveMembers() - returns members of a group (is transitive)